### PR TITLE
Support PHPStan 0.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": "^7.0",
         "psr/container": "^1.0",
-        "phpstan/phpstan": "^0.11"
+        "phpstan/phpstan": "^0.11|^0.12"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The extension works under v0.12, but the composer requirements don't allow it.

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for bnf/phpstan-psr-container ^0.11.0 -> satisfiable by bnf/phpstan-psr-container[0.11.0].
    - Conclusion: remove phpstan/phpstan 0.12.5
    - Conclusion: don't install phpstan/phpstan 0.12.5
    - bnf/phpstan-psr-container 0.11.0 requires phpstan/phpstan ^0.11 -> satisfiable by phpstan/phpstan[0.11, 0.11.1, 0.11.10, 0.11.11, 0.11.12, 0.11.13, 0.11.14, 0.11.15, 0.11.16, 0.11.17, 0.11.18, 0.11.19, 0.11.2, 0.11.3, 0.11.4, 0.11.5, 0.11.6, 0.11.7, 0.11.8, 0.11.9].
    - Can only install one of: phpstan/phpstan[0.11, 0.12.5].
    ...
    - Installation request for phpstan/phpstan (locked at 0.12.5) -> satisfiable by phpstan/phpstan[0.12.5].
```